### PR TITLE
Sort keys for messages and metadata

### DIFF
--- a/dist/lingui-multi.js
+++ b/dist/lingui-multi.js
@@ -93,11 +93,11 @@ const extractCatalogs = (packageFile, packageObject, localesDir, locales) => {
 
     const minimalCatalog = Object.assign(createMinimalCatalog(complexCatalog), loadMinimalCatalogBypassErrors(localesDir, locale))
 
-    writeMinimalCatalog(minimalCatalog, localesDir, locale)
+    writeMinimalCatalog(sortObjectKeys(minimalCatalog), localesDir, locale)
 
     // Write metadata catalog only to source locale directory
     if (locale === options.sourceLocale) {
-      writeMetadataCatalog(complexCatalog, localesDir, locale)
+      writeMetadataCatalog(sortObjectKeys(complexCatalog), localesDir, locale)
     }
 
     console.info(`${locale} ${Object.keys(minimalCatalog).length}`)
@@ -264,6 +264,14 @@ const _getJsonFilePath = (directory, locale, suffix = '') => {
     throw new Error(`file missing: ${jsonFile}`)
   }
   return jsonFile
+}
+
+const sortObjectKeys = (obj) => {
+  const sortedObj = {};
+  Object.keys(obj).sort().forEach(function(key) {
+    sortedObj[key] = obj[key];
+  });
+  return sortedObj;
 }
 
 const createMinimalCatalog = (complexCatalog) =>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sector-labs/lingui-multi",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Command line utility to compile multiple catalogs from a single js-lingui messages.json file.",
   "repository": {
     "url": "git+ssh://github.com/SectorLabs/lingui-multi.git",


### PR DESCRIPTION
Since Javascript keys are kept in the same order they are added to the object, a simple solution was to create another empty object and add the keys in order.

If you have another solution, let me know. 