### PR TITLE
Add LINGUI_MULTI_IGNORE_PATTERNS to improve the control of ignored folders, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Add the following to your project's package.json file:
  }
 ```
 
-Each sub-catalog will include all the i18n translations used in the source paths defined for lingui in the package.json file minus the ignore patterns defined either in the lingui configuration or the lingui-multi sub-catalog configuration.
+Each sub-catalog will include all the i18n translations used in the source paths defined for lingui in the package.json file minus the ignore patterns defined either in the lingui configuration, the lingui-multi sub-catalog configuration or in the environment variable named `LINGUI_MULTI_IGNORE_PATTERNS` (regular expression string, for example `"ignore_folder_2|ignore_folder_3"`).
+
 
 **Note: Lingui multi requires your existing messages.json file to be in `minimal` format. If it is in any other format please convert to the minimal format before using this utility**
 
@@ -50,4 +51,3 @@ The default value for package.json path is: `./package.json`
 The default value for locales directory is: `./locale`
 
 The utility will pick up lingui configuration and lingui-multi configuration from the package.json file and spit out catalog files in the locale directory with the format `<sub_catalog>.messages.js` for each sub-catalog and a `messages.js` catalog with all translations excluding only those that are defined in the `lingui` settings in `package.json` file of the application.
-

--- a/tests/Compile.spec.js
+++ b/tests/Compile.spec.js
@@ -1,0 +1,154 @@
+'use strict'
+
+const exec = require('child_process').exec;
+
+const chai = require('chai');
+const tmp = require('tmp');
+const path = require('path');
+const fs = require('fs');
+const expect = chai.expect;
+
+const lingui = './dist/lingui-multi.js';
+const linguiCompile = './dist/lingui-multi.js compile';
+
+// Creates a temporary folder to store the compiled catalogs, autoremoved at the the process exit.
+const createResultsFolder = () => {
+    const tmpFolder = tmp.dirSync({
+        unsafeCleanup: true,
+    });
+
+    fs.mkdirSync(path.join(tmpFolder.name, 'ar'));
+    fs.mkdirSync(path.join(tmpFolder.name, 'en'));
+
+    return tmpFolder;
+}
+
+describe('lingui-multi cli', () => {
+    it('shows a help text, when --help is provided', (done) => {
+        exec([lingui, '--help'].join(' '), function(error, stdout, stderr) {
+            expect(error).to.be.null;
+            expect(stdout).to.contain('Usage: lingui-multi [options] [command]');
+            expect(stdout).to.contain('compile');
+            expect(stdout).to.contain('extract');
+            done();
+        });
+    });
+
+    describe('Compile', () => {
+        it('shows a help text, when --help is provided', (done) => {
+            exec([linguiCompile, '--help'].join(' '), function(error, stdout, stderr) {
+                expect(error).to.be.null;
+                expect(stdout).to.contain('Usage: compile [options] [packageFile] [localesFolder]');
+                expect(stdout).to.contain('--removeIdentityPairs');
+                expect(stdout).to.contain('--targetFolder');
+                expect(stdout).to.contain('--strict');
+                done();
+            });
+        });
+
+        it('creates valid compiled catalogs', (done) => {
+            const tmpFolder = createResultsFolder();
+
+            exec([
+                    linguiCompile,
+                    `--targetFolder=${tmpFolder.name}`,
+                    './tests/resources/package.json',
+                    './tests/resources/locale',
+                ].join(' '),
+            function(error, stdout, stderr) {
+                expect(error).to.be.null;
+
+                const catalogEn = require(path.join(`${tmpFolder.name}`, 'en/messages.js'));
+                const catalogAr = require(path.join(`${tmpFolder.name}`, 'ar/messages.js'));
+                const subCatalogEn = require(path.join(`${tmpFolder.name}`, 'en/sub-catalog.messages.js'));
+                const subCatalogAr = require(path.join(`${tmpFolder.name}`, 'ar/sub-catalog.messages.js'));
+
+                expect(catalogEn.messages).to.eql({
+                    'Test Heading': 'Test Heading',
+                    'Test Paragraph': 'Test Paragraph',
+                    'Test Excluded Heading': 'Test Excluded Heading',
+                    'Test Excluded Paragraph': 'Test Excluded Paragraph'
+                });
+
+                expect(subCatalogEn.messages).to.eql({
+                    'Test Heading': 'Test Heading',
+                    'Test Paragraph': 'Test Paragraph',
+                });
+
+                expect(catalogAr.messages).to.eql({
+                    'Test Heading': 'Arabic Test Heading',
+                    'Test Paragraph': 'Arabic Test Paragraph',
+                    'Test Excluded Heading': 'Arabic Test Excluded Heading',
+                    'Test Excluded Paragraph': 'Arabic Test Excluded Paragraph'
+                });
+
+                expect(subCatalogAr.messages).to.eql({
+                    'Test Heading': 'Arabic Test Heading',
+                    'Test Paragraph': 'Arabic Test Paragraph',
+                });
+
+                done();
+            });
+        });
+
+        it('creates valid, smaller compiled catalogs with --removeIdentityPairs', (done) => {
+            const tmpFolder = createResultsFolder();
+
+            exec([
+                    linguiCompile,
+                    `--targetFolder=${tmpFolder.name}`,
+                    '--removeIdentityPairs',
+                    './tests/resources/package.json',
+                    './tests/resources/locale',
+                ].join(' '),
+            function(error, stdout, stderr) {
+                expect(error).to.be.null;
+
+                const catalogEn = require(path.join(`${tmpFolder.name}`, 'en/messages.js'));
+                const catalogAr = require(path.join(`${tmpFolder.name}`, 'ar/messages.js'));
+
+                expect(catalogEn.messages).to.eql({});
+
+                expect(catalogAr.messages).to.eql({
+                    'Test Heading': 'Arabic Test Heading',
+                    'Test Paragraph': 'Arabic Test Paragraph',
+                    'Test Excluded Heading': 'Arabic Test Excluded Heading',
+                    'Test Excluded Paragraph': 'Arabic Test Excluded Paragraph'
+                });
+
+                done();
+            });
+        });
+
+        it('takes LINGUI_MULTI_IGNORE_PATTERNS into account when creating the catalogs', (done) => {
+            const tmpFolder = createResultsFolder();
+            process.env.LINGUI_MULTI_IGNORE_PATTERNS = 'test-code-excluded.jsx';
+
+            exec([
+                    linguiCompile,
+                    `--targetFolder=${tmpFolder.name}`,
+                    './tests/resources/package.json',
+                    './tests/resources/locale',
+                ].join(' '),
+            function(error, stdout, stderr) {
+                expect(error).to.be.null;
+
+                const catalogEn = require(path.join(`${tmpFolder.name}`, 'en/messages.js'));
+                const catalogAr = require(path.join(`${tmpFolder.name}`, 'ar/messages.js'));
+
+                expect(catalogEn.messages).to.eql({
+                    'Test Heading': 'Test Heading',
+                    'Test Paragraph': 'Test Paragraph',
+                });
+
+                expect(catalogAr.messages).to.eql({
+                    'Test Heading': 'Arabic Test Heading',
+                    'Test Paragraph': 'Arabic Test Paragraph',
+                });
+
+                process.env.LINGUI_MULTI_IGNORE_PATTERNS = undefined;
+                done();
+            });
+        });
+    });
+});

--- a/tests/Config.spec.js
+++ b/tests/Config.spec.js
@@ -24,7 +24,7 @@ describe('Configuration', () => {
     })
 
     it('should throw error on malformed file', () => {
-      expect(() => Program.loadPackageConfig('./tests/resources/src/test-code.jsx')).to.throw('package.json is not a valid JSON file')
+      expect(() => Program.loadPackageConfig('./tests/resources/src/test-code.jsx')).to.throw('is not a valid JSON file')
     })
   })
 
@@ -46,7 +46,7 @@ describe('Configuration', () => {
     })
 
     it('should throw error on malformed file', () => {
-      expect(() => Program.loadPackageConfig('./tests/resources/src/test-code.jsx')).to.throw('package.json is not a valid JSON file')
+      expect(() => Program.loadPackageConfig('./tests/resources/src/test-code.jsx')).to.throw('is not a valid JSON file')
     })
   })
 })


### PR DESCRIPTION
We can use this variable to configure extra ignore folders, if needed. The package.json is kind of static, and if you generate multiple sites from the same codebase you want to also have a way to configure the ignore folders "programatically"